### PR TITLE
Fix REDIS_IP export

### DIFF
--- a/commands
+++ b/commands
@@ -96,7 +96,7 @@ case "$1" in
         ID=$(docker ps -a | grep "$REDIS_IMAGE":latest |  awk '{print $1}')
         IP=$(docker inspect $ID | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
         # Write REDIS_IP to app's ENV file
-        URL="export REDIS_IP=$IP"
+        URL="REDIS_IP=$IP"
         cat "/home/git/$APP/ENV" | grep "$URL" || echo "export $URL" >> "/home/git/$APP/ENV"
         echo
         echo "-----> $APP linked to $REDIS_IMAGE container"


### PR DESCRIPTION
The export which is written into the ENV file of the container contains a double 'export'. This pull request fixes this.
