### PR TITLE
Fix for issue #9: Moving persistent volumes to $DOKKU_ROOT.

### DIFF
--- a/commands
+++ b/commands
@@ -28,13 +28,14 @@ case "$1" in
         exit 1
     fi
     # Check if an existing DB volume exists
-    if [[ -d "/var/lib/docker/volumes/redis-$APP" ]]; then
-        VOLUME="/var/lib/docker/volumes/redis-$APP/layer:/opt/redis"
+    HOST_DIR="$DOKKU_ROOT/.redis/volume-$APP"
+    if [[ -d $HOST_DIR ]]; then
         echo
         echo "-----> Reusing redis/$APP database"
     else
-        VOLUME="/opt/redis"
+        mkdir -p $HOST_DIR
     fi
+    VOLUME="$HOST_DIR:/opt/redis"
     # Stop existing container with the same persistent Redis
     ID=$(docker ps | grep "$REDIS_IMAGE":latest |  awk '{print $1}')
     if [[ ! -z "$ID" ]]; then
@@ -48,12 +49,6 @@ case "$1" in
     # Launch container
     ID=$(docker run -v $VOLUME -p 6379 -d $REDIS_IMAGE /bin/start_redis.sh)
     sleep 4
-    # Rename persistent volume
-    if [[ ! -d "/var/lib/docker/volumes/redis-$APP" ]]; then
-        VOLUME_PATH=$(docker inspect $ID | grep "/var/lib/docker/volumes/" | awk '{print $2}' | sed -e"s/\/layer//" | sed -e's/"//g')
-        mv $VOLUME_PATH "/var/lib/docker/volumes/redis-$APP"
-        sleep 1
-    fi
     # Link to a potential existing app
     dokku redis:link $APP $APP
     echo
@@ -75,8 +70,8 @@ case "$1" in
         docker rmi $IMAGE
     fi
     # Remove persistent volume
-    if [[ -d "/var/lib/docker/volumes/redis-$APP" ]]; then
-        rm -rf "/var/lib/docker/volumes/redis-$APP"
+    if [[ -d $HOST_DIR ]]; then
+        rm -rf $HOST_DIR
     fi
     echo
     echo "-----> Redis container deleted: $REDIS_IMAGE"


### PR DESCRIPTION
I had the same issue as described in https://github.com/luxifer/dokku-redis-plugin/issues/9.
(Disclaimer: I'm a total docker/dokku newb, so apologies if this goes in completely the wrong direction.)

Looking at the source and the error message, the issue seems to be that the user running dokku doesn't necessarily have permission to write to /var/lib/docker/volumes and therefore cannot rename the docker volume after it's been created. The solution seems to be putting the persistent volumes somewhere under $DOKKU_ROOT, where the user running dokku is guaranteed to have write permissions. This allows for removing the rename step and incidentally also seems to be what some other plugins are doing: see https://github.com/jeffutter/dokku-mongodb-plugin/blob/master/commands#L7 and https://github.com/Kloadut/dokku-pg-plugin/blob/master/commands#L40.

I wasn't quite sure how to test this, so this patch is very much in a "works-on-my-machine" state! :)
