### PR TITLE
Fix $IMAGE variable.

### DIFF
--- a/pre-release
+++ b/pre-release
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-APP="$1"; IMAGE="$2";
+APP="$1"; IMAGE="app/$APP";
 dokku redis:link $APP $APP


### PR DESCRIPTION
(Although this may not matter as it seems as if it's not used in this script.)

In the current version of dokku the $IMAGE variable is no longer passed in to pluginhooks, causing this script to break. The fix is easy, just need to change it from being `IMAGE="$2"` to `IMAGE="app/$APP"`.

More details about the fix, and the commit that changed this, here:
https://github.com/progrium/dokku/issues/313#issuecomment-31210408
