### PR TITLE
change app namespace to dokku for docker 0.10 compatibility

### DIFF
--- a/pre-release
+++ b/pre-release
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-APP="$1"; IMAGE="app/$APP";
+APP="$1"; IMAGE="dokku/$APP";
 dokku redis:link $APP $APP


### PR DESCRIPTION
From this PR progrium/dokku#535, dokku changed the app namespace to dokku since docker 0.10 required a minimum of 4 characters in the namespace.
