### PR TITLE
Fixes for reboot/etc

### DIFF
--- a/commands
+++ b/commands
@@ -100,17 +100,11 @@ case "$1" in
         ID=$(docker ps -a | grep "$REDIS_IMAGE":latest |  awk '{print $1}')
         if [[ -n "$ID" ]]; then
             IP=$(docker inspect $ID | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
-            # Write REDIS_IP to app's ENV file
-            REDIS_URL="REDIS_URL=redis://$IP:6379"
-            REDIS_IP="REDIS_IP=$IP"
-            REDIS_PORT="REDIS_PORT=6379"
-            ENV_FILE="$DOKKU_ROOT/$APP/ENV"
-            if [[ ! -f $ENV_FILE ]]; then
-                touch $ENV_FILE
-            fi
-            ENV_TEMP=$(cat "${ENV_FILE}" | sed "/^export \(REDIS_URL\|REDIS_IP\|REDIS_PORT\)=/ d")
-            ENV_TEMP="${ENV_TEMP}\nexport ${REDIS_URL}\nexport ${REDIS_IP}\nexport ${REDIS_PORT}"
-            echo -e "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE
+            # it seems like the dokku way of doing things is using dokku config:set to set environment variables, 
+            # eg, not setting them via modifying the app's ENV file
+            dokku config:set $APP "REDIS_URL=redis://$IP:6379"
+            dokku config:set $APP "REDIS_IP=$IP"
+            dokku config:set $APP "REDIS_PORT=6379"
             echo
             echo "-----> $APP linked to $REDIS_IMAGE container"
         fi

--- a/pre-deploy
+++ b/pre-deploy
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e;
+
+APP="$1"
+REDIS_APP_IMAGE="redis/$APP"
+REDIS_APP_IMAGE_ID=$(docker images | grep "$REDIS_IMAGE" | awk '{print $3}')
+
+# verifies that an app mimage has been mae
+if [[ -n $REDIS_APP_IMAGE_ID ]]; then
+  echo "-----> Checking status of Redis"
+
+  REDIS_IMAGE=$(docker images | grep "luxifer/redis " | awk '{print $3}')
+  if [[ -z $REDIS_IMAGE ]]; then
+    echo "Redis image not found...Did you run 'dokku plugins-install' ?"
+    exit 1
+  fi
+
+  echo "	Found image redis/$APP"
+  echo -n "	Checking status..."
+
+  # since this is in pre-deploy, i don't think we'll run into a situation where the container is already started
+  # but the postgres guys had it.
+  # "never say never"
+  REDIS_APP_IMAGE_CONTAINER_ID=$(docker ps | grep "$REDIS_APP_IMAGE" | awk '{print $1}')
+  if [[ -n $REDIS_APP_IMAGE_CONTAINER_ID ]]; then
+    echo "ok."
+  else
+    echo "stopped."
+    # this is pretty much ripped from redis:create
+    HOST_DIR="$DOKKU_ROOT/.redis/volume-$APP"
+    if [[ -d $HOST_DIR ]]; then
+      echo
+      echo "-----> Reusing redis/$APP database"
+    else
+      mkdir -p $HOST_DIR
+    fi
+    VOLUME="$HOST_DIR:/var/lib/redis"
+    echo -n "	Launching $REDIS_APP_IMAGE..."
+    echo "COMMAND: docker run -v $VOLUME -p 6379 -d $REDIS_APP_IMAGE /bin/start_redis.sh"
+    ID=$(docker run -v $VOLUME -p 6379 -d $REDIS_APP_IMAGE /bin/start_redis.sh)
+    sleep 4
+    dokku redis:link $APP $APP
+    sleep 1
+    echo "ok."
+  fi
+fi
+


### PR DESCRIPTION
* Dokku way of setting environment variables for applications doesn't involve modifying ~dokku/appname/ENV. it's now dokku config:set ... it's up to dokku to create ~dokku/appname/ENV

* I looked at how postgres implemented their pre-deploy scripts and pretty much copied @Kloadut 's work modifying it to work with your implementation of redis.

* Since pre-deploy runs before the container for the app gets started...it means that if the machine/vps/etc that's running Dokku reboots, redis will now come up, configure the environment variables, and then dokku will start the app container. I believe this resolves issue #36 .

-g
