### PR TITLE
Use single config:set call to set all environment variables

### DIFF
--- a/commands
+++ b/commands
@@ -102,9 +102,7 @@ case "$1" in
             IP=$(docker inspect $ID | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
             # it seems like the dokku way of doing things is using dokku config:set to set environment variables, 
             # eg, not setting them via modifying the app's ENV file
-            dokku config:set $APP "REDIS_URL=redis://$IP:6379"
-            dokku config:set $APP "REDIS_IP=$IP"
-            dokku config:set $APP "REDIS_PORT=6379"
+            dokku config:set $APP "REDIS_URL=redis://$IP:6379" "REDIS_IP=$IP" "REDIS_PORT=6379"
             echo
             echo "-----> $APP linked to $REDIS_IMAGE container"
         fi


### PR DESCRIPTION
When creating a new redis container for an app, the app gets restarted three times when the `REDIS_*` vars are set:
```
root@trillium:/# dokku redis:create testapi
-----> Setting config vars
       REDIS_URL: redis://172.17.0.9:6379
-----> Restarting app testapi
-----> Setting config vars
       REDIS_IP: 172.17.0.9
-----> Restarting app testapi
-----> Setting config vars
       REDIS_PORT: 6379
-----> Restarting app testapi
```

You can pass as many variables to `config:set` as you want, so I've updated the `commands` script accordingly. Now the app only restarts once, as I expected.